### PR TITLE
feat: 게시글 이미지 업로드 api 연동

### DIFF
--- a/app/posts/new/page.tsx
+++ b/app/posts/new/page.tsx
@@ -27,6 +27,7 @@ export default function NewPostPage() {
   const [currentStep, setCurrentStep] = useState(1);
   const [hobbyId, setHobbyId] = useState<number | null>(null);
   const [postId, setPostId] = useState<number | null>(null);
+  const [photoFiles, setPhotoFiles] = useState<File[]>([]);
   const [formData, setFormData] = useState<PostFormData>({
     goods: '',
     category: '스포츠',
@@ -258,7 +259,7 @@ export default function NewPostPage() {
     }
   };
 
-  // Step 3: 사진 등록 (임시 패스)
+  // Step 3: 사진 등록 (S3 업로드)
   const handleStep3Next = async () => {
     const targetPostId = postId || Number(localStorage.getItem('tempPostId'));
     if (!targetPostId) {
@@ -266,13 +267,29 @@ export default function NewPostPage() {
       return;
     }
 
-    if (formData.photos.length === 0) {
+    if (photoFiles.length === 0) {
       alert('최소 1장의 사진을 등록해주세요.');
       return;
     }
 
-    console.log("🚧 사진 등록 API 건너뛰고 4단계로 이동");
-    setCurrentStep(4);
+    const accessToken = localStorage.getItem('accessToken');
+    if (!accessToken) {
+      alert('로그인이 필요합니다.');
+      router.push('/login');
+      return;
+    }
+
+    try {
+      // S3 이미지 업로드 API 호출
+      const { uploadPostImages } = await import('../../../lib/api');
+      const result = await uploadPostImages(targetPostId, photoFiles);
+      
+      console.log('✅ 이미지 업로드 완료:', result);
+      setCurrentStep(4);
+    } catch (error: any) {
+      console.error('Image upload error:', error);
+      alert('이미지 업로드 중 오류가 발생했어요: ' + (error?.message ?? '알 수 없는 오류'));
+    }
   };
 
   // Step 4: 가격 설정 (최종 등록)
@@ -370,6 +387,7 @@ export default function NewPostPage() {
               onPhotoRemove={handlePhotoRemove}
               onNext={handleStep3Next}
               onPrevious={() => setCurrentStep(2)}
+              onPhotoFilesChange={(files) => setPhotoFiles(files)}
             />
           )}
           {currentStep === 4 && (

--- a/components/post-register/Step3Photos.tsx
+++ b/components/post-register/Step3Photos.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useRef, useEffect } from 'react';
 import { FormData } from './types';
 
 interface Step3PhotosProps {
@@ -9,6 +10,7 @@ interface Step3PhotosProps {
   onPhotoRemove: (index: number) => void;
   onNext: () => void;
   onPrevious: () => void;
+  onPhotoFilesChange?: (files: File[]) => void;
 }
 
 export default function Step3Photos({ 
@@ -16,8 +18,77 @@ export default function Step3Photos({
   onPhotoAdd, 
   onPhotoRemove, 
   onNext, 
-  onPrevious 
+  onPrevious,
+  onPhotoFilesChange
 }: Step3PhotosProps) {
+  const [photoFiles, setPhotoFiles] = useState<File[]>([]);
+  const [previewUrls, setPreviewUrls] = useState<string[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // 파일 선택 시 미리보기 URL 생성
+  useEffect(() => {
+    const urls = photoFiles.map(file => URL.createObjectURL(file));
+    setPreviewUrls(urls);
+
+    // cleanup: 메모리 누수 방지
+    return () => {
+      urls.forEach(url => URL.revokeObjectURL(url));
+    };
+  }, [photoFiles]);
+
+  // 부모 컴포넌트에 파일 목록 전달
+  useEffect(() => {
+    if (onPhotoFilesChange) {
+      onPhotoFilesChange(photoFiles);
+    }
+  }, [photoFiles, onPhotoFilesChange]);
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    const imageFiles = files.filter(file => file.type.startsWith('image/'));
+    
+    if (photoFiles.length + imageFiles.length > 5) {
+      alert('최대 5장까지만 업로드할 수 있습니다.');
+      return;
+    }
+
+    setPhotoFiles(prev => [...prev, ...imageFiles]);
+    
+    // formData.photos도 업데이트 (미리보기 URL)
+    const newUrls = imageFiles.map(file => URL.createObjectURL(file));
+    onInputChange('photos', [...formData.photos, ...newUrls]);
+
+    // input 초기화 (같은 파일 다시 선택 가능하도록)
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handlePhotoRemove = (index: number) => {
+    // 미리보기 URL 정리
+    if (previewUrls[index]) {
+      URL.revokeObjectURL(previewUrls[index]);
+    }
+
+    // 파일 목록에서 제거
+    const newFiles = photoFiles.filter((_, i) => i !== index);
+    setPhotoFiles(newFiles);
+
+    // formData.photos에서도 제거
+    const newPhotos = formData.photos.filter((_, i) => i !== index);
+    onInputChange('photos', newPhotos);
+    
+    // 기존 핸들러도 호출
+    onPhotoRemove(index);
+  };
+
+  const handleUploadClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  // 미리보기용 URL (파일이 있으면 파일에서, 없으면 기존 URL)
+  const displayPhotos = previewUrls.length > 0 ? previewUrls : formData.photos;
+
   return (
     <div className="space-y-6">
       <div className="text-center mb-8">
@@ -25,8 +96,17 @@ export default function Step3Photos({
         <p className="text-gray-500 text-sm">물품의 전체 모습과 하자 부분을 확인할 수 있도록 여러 장의 사진을 올려주세요. (최대 5장)</p>
       </div>
 
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        onChange={handleFileSelect}
+        className="hidden"
+      />
+
       <div className="grid grid-cols-2 gap-3">
-        {formData.photos.map((photo, index) => (
+        {displayPhotos.map((photo, index) => (
           <div key={index} className="relative aspect-square">
             <img
               src={photo}
@@ -34,7 +114,7 @@ export default function Step3Photos({
               className="w-full h-full object-cover rounded-2xl object-top"
             />
             <button
-              onClick={() => onPhotoRemove(index)}
+              onClick={() => handlePhotoRemove(index)}
               className="absolute -top-2 -right-2 w-6 h-6 bg-red-500 text-white rounded-full flex items-center justify-center cursor-pointer"
             >
               <i className="ri-close-line text-sm"></i>
@@ -47,9 +127,9 @@ export default function Step3Photos({
           </div>
         ))}
 
-        {formData.photos.length < 5 && (
+        {displayPhotos.length < 5 && (
           <button
-            onClick={onPhotoAdd}
+            onClick={handleUploadClick}
             className="aspect-square border-2 border-dashed border-gray-300 rounded-2xl flex flex-col items-center justify-center text-gray-400 hover:border-purple-400 hover:text-purple-400 transition-colors cursor-pointer"
           >
             <div className="w-8 h-8 flex items-center justify-center">
@@ -85,9 +165,9 @@ export default function Step3Photos({
         </button>
         <button
           onClick={onNext}
-          disabled={formData.photos.length === 0}
+          disabled={displayPhotos.length === 0}
           className={`flex-1 py-4 rounded-2xl font-medium transition-all whitespace-nowrap cursor-pointer ${
-            formData.photos.length > 0
+            displayPhotos.length > 0
               ? 'bg-gradient-to-r from-purple-500 to-purple-600 text-white hover:from-purple-600 hover:to-purple-700'
               : 'bg-gray-200 text-gray-400 cursor-not-allowed'
           }`}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -300,3 +300,29 @@ export async function getPostDetail(postId: number) {
   return response.result;
 }
 
+// 게시물 이미지 업로드
+export async function uploadPostImages(postId: number, images: File[]) {
+  const formData = new FormData();
+  images.forEach((image) => {
+    formData.append('images', image);
+  });
+
+  const authHeader = getAuthHeader();
+  const headers: HeadersInit = {
+    ...(authHeader && { Authorization: authHeader }),
+  };
+
+  const response = await fetch(`${API_BASE_URL}/posts/${postId}/image`, {
+    method: 'POST',
+    headers,
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error(`API Error: ${response.statusText}`);
+  }
+
+  const result = await response.json();
+  return result.result || result;
+}
+


### PR DESCRIPTION
이슈번호 #23 

## 변경사항
- 게시글 생성 시 이미지 업로드되도록 api 연동

## 스크린샷
<img width="2000" height="1011" alt="image" src="https://github.com/user-attachments/assets/8a992960-c2b3-40eb-945b-d9eb9107565b" />
[게시글 등록 과정]

<img width="787" height="434" alt="image" src="https://github.com/user-attachments/assets/988dfd9c-b9d7-4b2c-9bba-a1e24de684ea" />
[db에 이미지 저장]