### PR TITLE
fix: 사진 크기 조정

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -474,7 +474,7 @@ export default function Home() {
               <p className="text-gray-500 text-sm">로딩 중...</p>
             </div>
           ) : products.length > 0 ? (
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 gap-4 lg:gap-6 w-full max-w-6xl xl:max-w-7xl mx-auto">
               {products.map((product) => (
                 <ProductCard key={product.id} product={product} />
               ))}

--- a/app/product/[id]/ProductDetail.tsx
+++ b/app/product/[id]/ProductDetail.tsx
@@ -481,14 +481,14 @@ export default function ProductDetail({ productId }: ProductDetailProps) {
     <div className="min-h-screen bg-gradient-to-br from-purple-50 to-blue-50">
       <Header />
       
-      <div className="px-4 pt-6 pb-60">
+      <div className="px-4 pt-6 pb-60 max-w-2xl mx-auto">
         {/* 상품 이미지 캐러셀 */}
         <div className="relative mb-6">
-          <div className="aspect-square rounded-2xl overflow-hidden bg-white shadow-lg">
+          <div className="aspect-square md:aspect-auto md:min-h-[400px] md:max-h-[600px] rounded-2xl overflow-hidden bg-white shadow-lg flex items-center justify-center">
             <img 
               src={product.images[currentImageIndex]} 
               alt={product.title}
-              className="w-full h-full object-cover"
+              className="w-full h-full md:w-auto md:max-w-full md:max-h-full object-contain"
             />
           </div>
           

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -68,12 +68,12 @@ export default function ProductCard({ product }: ProductCardProps) {
 
   return (
     <Link href={`/product/${product.id}`}>
-      <div className="bg-white/80 backdrop-blur-sm rounded-3xl p-4 shadow-sm border border-white/20 hover:shadow-lg transition-all duration-300 cursor-pointer">
-        <div className="relative mb-3">
+      <div className="bg-white/80 backdrop-blur-sm rounded-3xl p-4 md:p-5 shadow-sm border border-white/20 hover:shadow-lg transition-all duration-300 cursor-pointer">
+        <div className="relative mb-3 md:mb-4 bg-gray-100 rounded-2xl overflow-hidden flex items-center justify-center h-40 md:h-52">
           <img
             src={product.image}
             alt={product.title}
-            className="w-full h-40 object-cover object-top rounded-2xl"
+            className="w-full h-full object-contain"
           />
           
           {product.available && (
@@ -99,33 +99,33 @@ export default function ProductCard({ product }: ProductCardProps) {
           )}
         </div>
 
-        <div className="space-y-2">
-          <div className="flex items-center gap-1">
-            <div className="w-5 h-5 bg-gradient-to-r from-purple-400 to-purple-600 rounded-full flex items-center justify-center">
+        <div className="space-y-2 md:space-y-2.5">
+          <div className="flex items-center gap-1 md:gap-1.5">
+            <div className="w-5 h-5 md:w-6 md:h-6 bg-gradient-to-r from-purple-400 to-purple-600 rounded-full flex items-center justify-center">
               <i className="ri-user-fill text-white text-xs"></i>
             </div>
-            <span className="text-xs font-medium text-gray-700 truncate">{product.owner}</span>
+            <span className="text-xs md:text-sm font-medium text-gray-700 truncate">{product.owner}</span>
             {product.verified && (
-              <div className="w-4 h-4 bg-gradient-to-r from-blue-500 to-blue-600 rounded-full flex items-center justify-center">
+              <div className="w-4 h-4 md:w-5 md:h-5 bg-gradient-to-r from-blue-500 to-blue-600 rounded-full flex items-center justify-center">
                 <i className="ri-check-fill text-white text-xs"></i>
               </div>
             )}
           </div>
 
-          <h3 className="font-bold text-gray-800 text-sm leading-tight line-clamp-2">{product.title}</h3>
+          <h3 className="font-bold text-gray-800 text-sm md:text-base leading-tight line-clamp-2">{product.title}</h3>
 
           <div className="flex items-center gap-1">
-            <i className="ri-star-fill text-yellow-400 text-xs"></i>
-            <span className="text-xs font-medium text-gray-700">{product.rating}</span>
-            <span className="text-xs text-gray-500">({product.reviews})</span>
+            <i className="ri-star-fill text-yellow-400 text-xs md:text-sm"></i>
+            <span className="text-xs md:text-sm font-medium text-gray-700">{product.rating}</span>
+            <span className="text-xs md:text-sm text-gray-500">({product.reviews})</span>
           </div>
 
-          <div className="flex items-center gap-1 text-xs text-gray-500">
-            <i className="ri-map-pin-line text-xs"></i>
+          <div className="flex items-center gap-1 text-xs md:text-sm text-gray-500">
+            <i className="ri-map-pin-line"></i>
             <span className="truncate">{product.location}</span>
           </div>
 
-          <div className="text-sm font-bold bg-gradient-to-r from-purple-600 to-purple-700 bg-clip-text text-transparent pt-2">
+          <div className="text-sm md:text-base font-bold bg-gradient-to-r from-purple-600 to-purple-700 bg-clip-text text-transparent pt-2">
             {product.price}
           </div>
         </div>

--- a/components/post-register/Step3Photos.tsx
+++ b/components/post-register/Step3Photos.tsx
@@ -14,7 +14,8 @@ interface Step3PhotosProps {
 }
 
 export default function Step3Photos({ 
-  formData, 
+  formData,
+  onInputChange,
   onPhotoAdd, 
   onPhotoRemove, 
   onNext, 
@@ -105,7 +106,7 @@ export default function Step3Photos({
         className="hidden"
       />
 
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-2 gap-4 max-w-lg mx-auto">
         {displayPhotos.map((photo, index) => (
           <div key={index} className="relative aspect-square">
             <img


### PR DESCRIPTION
## 변경사항
- 게시글 등록할 때 사진 크기 조정 - 최대 넓이 지정함
- 게시글 목록에서 게시글 카드 크기 반응형으로 조정

## 스크린샷
[게시글 목록-데스크톱]
<img width="1179" height="872" alt="image" src="https://github.com/user-attachments/assets/92fbdb93-5547-446c-9634-68db623afc75" />

[게시글 목록-모바일]
<img width="514" height="787" alt="image" src="https://github.com/user-attachments/assets/528a003a-e707-4d91-b97d-2978a0461927" />

[게시글 등록]
<img width="1180" height="857" alt="image" src="https://github.com/user-attachments/assets/8e33dd77-69ea-40b2-96c6-6b4fbf60286a" />

- 비율 이상해보이는지 확인하고 나중에 바꿔도 됩니다...