### PR TITLE
feat: 관리자 페이지 생성 및 신고 api 연동

### DIFF
--- a/app/admin/reports/page.tsx
+++ b/app/admin/reports/page.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getAllReports, getReportsByStatus, approveReport, type ReportResponse } from '@/lib/api';
+
+const REPORT_TYPES: Record<string, string> = {
+  MINOR_DAMAGE: '경미파손',
+  DAMAGE: '파손',
+  RETURN_DELAY: '반납 연체',
+  NOT_AS_DESCRIBED: '설명과 다름',
+  SCAM: '사기',
+  PROHIBITED_ITEM: '금지물품',
+  ABUSE: '욕설',
+  OTHER: '기타',
+};
+
+const REPORT_STATUSES = ['OPEN', 'IN_PROGRESS', 'APPROVED', 'REJECTED', 'RESOLVED', 'CLOSED'];
+
+export default function AdminReportsPage() {
+  const [reports, setReports] = useState<ReportResponse[]>([]);
+  const [selectedStatus, setSelectedStatus] = useState<string>('ALL');
+  const [isLoading, setIsLoading] = useState(false);
+  const [processingId, setProcessingId] = useState<number | null>(null);
+
+  useEffect(() => {
+    loadReports();
+  }, [selectedStatus]);
+
+  const loadReports = async () => {
+    setIsLoading(true);
+    try {
+      let reportsData: ReportResponse[];
+      if (selectedStatus === 'ALL') {
+        reportsData = await getAllReports();
+      } else {
+        reportsData = await getReportsByStatus(selectedStatus);
+      }
+      setReports(reportsData);
+    } catch (error: any) {
+      alert(`신고 목록 조회 실패: ${error.message}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleApprove = async (reportId: number, approved: boolean) => {
+    if (!confirm(approved ? '이 신고를 승인하시겠습니까? (자동결제가 실행됩니다.)' : '이 신고를 거부하시겠습니까?')) {
+      return;
+    }
+
+    setProcessingId(reportId);
+    try {
+      await approveReport(reportId, approved);
+      alert(approved ? '신고가 승인되었습니다.' : '신고가 거부되었습니다.');
+      loadReports();
+    } catch (error: any) {
+      alert(`처리 실패: ${error.message}`);
+    } finally {
+      setProcessingId(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8 px-4">
+      <div className="max-w-6xl mx-auto">
+        <h1 className="text-3xl font-bold mb-8">관리자 - 신고 관리</h1>
+
+        <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-xl font-semibold">신고 목록</h2>
+            <select
+              value={selectedStatus}
+              onChange={(e) => setSelectedStatus(e.target.value)}
+              className="px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="ALL">전체</option>
+              {REPORT_STATUSES.map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {isLoading ? (
+            <p className="text-center text-gray-500 py-8">로딩 중...</p>
+          ) : reports.length === 0 ? (
+            <p className="text-center text-gray-500 py-8">신고 내역이 없습니다.</p>
+          ) : (
+            <div className="space-y-4">
+              {reports.map((report) => (
+                <div key={report.id} className="border border-gray-200 rounded-md p-4">
+                  <div className="flex justify-between items-start mb-2">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2 mb-2">
+                        <h3 className="font-semibold text-lg">{report.title}</h3>
+                        <span className={`px-2 py-1 rounded text-xs ${
+                          report.status === 'APPROVED' ? 'bg-green-100 text-green-800' :
+                          report.status === 'REJECTED' ? 'bg-red-100 text-red-800' :
+                          report.status === 'OPEN' ? 'bg-blue-100 text-blue-800' :
+                          'bg-gray-100 text-gray-800'
+                        }`}>
+                          {report.status}
+                        </span>
+                        <span className="px-2 py-1 rounded text-xs bg-purple-100 text-purple-800">
+                          {REPORT_TYPES[report.type] || report.type}
+                        </span>
+                      </div>
+                      <p className="text-sm text-gray-600 mb-2">
+                        대여 ID: {report.rentId} | 신고자 ID: {report.userId}
+                        {report.delayDays && ` | 연체일수: ${report.delayDays}일`}
+                      </p>
+                      <p className="text-gray-700 mb-2">{report.content}</p>
+                      {report.imageUrl && (
+                        <a
+                          href={report.imageUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-600 hover:underline text-sm"
+                        >
+                          이미지 보기
+                        </a>
+                      )}
+                      <p className="text-xs text-gray-500 mt-2">
+                        접수일: {new Date(report.createdAt).toLocaleString('ko-KR')}
+                      </p>
+                    </div>
+                    <div className="flex flex-col gap-2 ml-4">
+                      {report.status === 'OPEN' || report.status === 'IN_PROGRESS' ? (
+                        <>
+                          <button
+                            onClick={() => handleApprove(report.id, true)}
+                            disabled={processingId === report.id}
+                            className="bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-sm whitespace-nowrap"
+                          >
+                            {processingId === report.id ? '처리 중...' : '승인'}
+                          </button>
+                          <button
+                            onClick={() => handleApprove(report.id, false)}
+                            disabled={processingId === report.id}
+                            className="bg-red-600 text-white py-2 px-4 rounded-md hover:bg-red-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-sm whitespace-nowrap"
+                          >
+                            {processingId === report.id ? '처리 중...' : '거부'}
+                          </button>
+                        </>
+                      ) : (
+                        <span className="text-sm text-gray-500">
+                          {report.status === 'APPROVED' ? '승인됨' : 
+                           report.status === 'REJECTED' ? '거부됨' : '처리 완료'}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/app/chat/[id]/ChatRoomClient.tsx
+++ b/app/chat/[id]/ChatRoomClient.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import BottomNavigation from '../../../components/BottomNavigation';
 import { getChatMessages, getCurrentUser, getChatRooms, getUserProfile, getReadStatus, getPeerReadStatus, updateRentDates, updateRentDailyPrice, updateRentRule, getRentByRoomId } from '../../../lib/api';
+import ReportModal from '../../../components/ReportModal';
 import { connectWebSocket, disconnectWebSocket, getStompClient } from '../../../lib/websocket';
 import { DEFAULT_PROFILE_IMAGE } from '../../../lib/constants';
 import { Client } from '@stomp/stompjs';
@@ -25,6 +26,8 @@ interface Message {
 export default function ChatRoomClient({ chatId }: ChatRoomClientProps) {
   const router = useRouter();
   const [showReportModal, setShowReportModal] = useState(false);
+  const [rentId, setRentId] = useState<number | null>(null);
+  const [isOwner, setIsOwner] = useState(false);
   const [selectedReportReason, setSelectedReportReason] = useState('');
   const [reportDetails, setReportDetails] = useState('');
   const [showActionMenu, setShowActionMenu] = useState(false);
@@ -168,6 +171,9 @@ export default function ChatRoomClient({ chatId }: ChatRoomClientProps) {
               startAt: rent.startAt,
               duedate: rent.duedate
             });
+            setRentId(rent.id);
+            // owner인지 확인 (room.ownerId와 user.id 비교)
+            setIsOwner(user.id === room.ownerId);
           }
         } catch (err) {
           console.error('Rent 정보 가져오기 실패:', err);
@@ -407,19 +413,25 @@ export default function ChatRoomClient({ chatId }: ChatRoomClientProps) {
     }
   };
 
-  const reportReasons = [
-    '제품에 공지된 것 이상의 하자가 있음',
-    '반납 기한을 지키지 않음',
-    '비매너 채팅',
-    '반납 후 보증금 책정 이상의 하자가 있음'
-  ];
-
-  const handleReport = () => {
-    if (selectedReportReason && reportDetails.trim()) {
-      setShowReportModal(false);
-      setSelectedReportReason('');
-      setReportDetails('');
-      alert('신고가 접수되었습니다. 검토 후 조치하겠습니다.');
+  // 신고 유형 정의
+  const getReportTypes = () => {
+    if (isOwner) {
+      // 빌려준 사람(owner)이 빌려간 사람(borrower)에게 신고 - 보증금 자동결제 관련
+      return [
+        { value: 'MINOR_DAMAGE', label: '경미파손' },
+        { value: 'DAMAGE', label: '파손' },
+        { value: 'RETURN_DELAY', label: '반납 연체' },
+        { value: 'OTHER', label: '기타' },
+      ];
+    } else {
+      // 빌려간 사람(borrower)이 빌려준 사람(owner)에게 신고 - 양방향 신고
+      return [
+        { value: 'NOT_AS_DESCRIBED', label: '설명과 다름' },
+        { value: 'SCAM', label: '사기' },
+        { value: 'PROHIBITED_ITEM', label: '금지물품' },
+        { value: 'ABUSE', label: '욕설' },
+        { value: 'OTHER', label: '기타' },
+      ];
     }
   };
 
@@ -1197,77 +1209,18 @@ export default function ChatRoomClient({ chatId }: ChatRoomClientProps) {
       )}
 
       {/* 신고하기 모달 */}
-      {showReportModal && (
-        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-          <div className="bg-white rounded-3xl p-6 w-full max-w-sm max-h-[90vh] overflow-y-auto">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-bold text-gray-800">대여자 신고</h3>
-              <button
-                onClick={() => {
-                  setShowReportModal(false);
-                  setSelectedReportReason('');
-                  setReportDetails('');
-                }}
-                className="w-8 h-8 flex items-center justify-center"
-              >
-                <i className="ri-close-line text-gray-500 text-xl"></i>
-              </button>
-            </div>
-            
-            <p className="text-sm text-gray-600 mb-4">신고 사유를 선택해주세요:</p>
-            
-            <div className="space-y-3 mb-6">
-              {reportReasons.map((reason) => (
-                <label key={reason} className="flex items-start gap-3 cursor-pointer">
-                  <input
-                    type="radio"
-                    name="reportReason"
-                    value={reason}
-                    checked={selectedReportReason === reason}
-                    onChange={(e) => setSelectedReportReason(e.target.value)}
-                    className="w-4 h-4 text-purple-600 mt-0.5 flex-shrink-0"
-                  />
-                  <span className="text-sm text-gray-700 leading-relaxed">{reason}</span>
-                </label>
-              ))}
-            </div>
-            
-            {/* 구체적인 사유 입력 */}
-            <div className="mb-6">
-              <p className="text-sm text-gray-600 mb-2">구체적인 사유를 적어주세요:</p>
-              <textarea
-                value={reportDetails}
-                onChange={(e) => setReportDetails(e.target.value)}
-                placeholder="신고 사유에 대한 자세한 내용을 입력해주세요..."
-                maxLength={500}
-                className="w-full h-24 p-3 border border-gray-200 rounded-2xl text-sm resize-none focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-              />
-              <div className="flex justify-end mt-1">
-                <span className="text-xs text-gray-400">{reportDetails.length}/500</span>
-              </div>
-            </div>
-            
-            <div className="flex gap-3">
-              <button
-                onClick={() => {
-                  setShowReportModal(false);
-                  setSelectedReportReason('');
-                  setReportDetails('');
-                }}
-                className="flex-1 py-3 bg-gray-100 text-gray-600 rounded-2xl font-medium hover:bg-gray-200 transition-colors"
-              >
-                취소
-              </button>
-              <button
-                onClick={handleReport}
-                disabled={!selectedReportReason || !reportDetails.trim()}
-                className="flex-1 py-3 bg-gradient-to-r from-red-500 to-red-600 text-white rounded-2xl font-medium hover:from-red-600 hover:to-red-700 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                신고하기
-              </button>
-            </div>
-          </div>
-        </div>
+      {showReportModal && rentId && (
+        <ReportModal
+          isOpen={showReportModal}
+          onClose={() => {
+            setShowReportModal(false);
+            setSelectedReportReason('');
+            setReportDetails('');
+          }}
+          rentId={rentId}
+          reportTypes={getReportTypes()}
+          isOwner={isOwner}
+        />
       )}
 
       <BottomNavigation />

--- a/app/report/page.tsx
+++ b/app/report/page.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createReport, getMyReports, type ReportResponse, type CreateReportRequest } from '@/lib/api';
+
+const REPORT_TYPES = {
+  // 보증금 자동결제 관련 (빌려준 사람만)
+  MINOR_DAMAGE: '경미파손',
+  DAMAGE: '파손',
+  RETURN_DELAY: '반납 연체',
+  // 양방향 신고
+  NOT_AS_DESCRIBED: '설명과 다름',
+  SCAM: '사기',
+  PROHIBITED_ITEM: '금지물품',
+  ABUSE: '욕설',
+  OTHER: '기타',
+};
+
+export default function ReportPage() {
+  const router = useRouter();
+  const [rentId, setRentId] = useState<string>('');
+  const [reportType, setReportType] = useState<string>('');
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [imageUrl, setImageUrl] = useState('');
+  const [delayDays, setDelayDays] = useState<string>('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [myReports, setMyReports] = useState<ReportResponse[]>([]);
+  const [showMyReports, setShowMyReports] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!rentId || !reportType || !title || !content) {
+      alert('모든 필수 항목을 입력해주세요.');
+      return;
+    }
+
+    if (reportType === 'RETURN_DELAY' && (!delayDays || parseInt(delayDays) <= 0)) {
+      alert('반납 연체 신고 시 연체일수를 입력해주세요.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const request: CreateReportRequest = {
+        rentId: parseInt(rentId),
+        type: reportType,
+        title,
+        content,
+        imageUrl: imageUrl || undefined,
+        delayDays: delayDays ? parseInt(delayDays) : undefined,
+      };
+
+      await createReport(request);
+      alert('신고가 접수되었습니다.');
+      // 폼 초기화
+      setRentId('');
+      setReportType('');
+      setTitle('');
+      setContent('');
+      setImageUrl('');
+      setDelayDays('');
+    } catch (error: any) {
+      alert(`신고 접수 실패: ${error.message}`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleLoadMyReports = async () => {
+    try {
+      const reports = await getMyReports();
+      setMyReports(reports);
+      setShowMyReports(true);
+    } catch (error: any) {
+      alert(`신고 목록 조회 실패: ${error.message}`);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8 px-4">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-3xl font-bold mb-8">신고하기</h1>
+
+        <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+          <h2 className="text-xl font-semibold mb-4">신고 접수</h2>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                대여 ID *
+              </label>
+              <input
+                type="number"
+                value={rentId}
+                onChange={(e) => setRentId(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                required
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                신고 유형 *
+              </label>
+              <select
+                value={reportType}
+                onChange={(e) => setReportType(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                required
+              >
+                <option value="">선택하세요</option>
+                <optgroup label="보증금 자동결제 관련 (빌려준 사람만)">
+                  <option value="MINOR_DAMAGE">경미파손</option>
+                  <option value="DAMAGE">파손</option>
+                  <option value="RETURN_DELAY">반납 연체</option>
+                  <option value="OTHER">기타</option>
+                </optgroup>
+                <optgroup label="양방향 신고">
+                  <option value="NOT_AS_DESCRIBED">설명과 다름</option>
+                  <option value="SCAM">사기</option>
+                  <option value="PROHIBITED_ITEM">금지물품</option>
+                  <option value="ABUSE">욕설</option>
+                  <option value="OTHER">기타</option>
+                </optgroup>
+              </select>
+            </div>
+
+            {reportType === 'RETURN_DELAY' && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  연체일수 *
+                </label>
+                <input
+                  type="number"
+                  value={delayDays}
+                  onChange={(e) => setDelayDays(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  min="1"
+                  required
+                />
+              </div>
+            )}
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                제목 *
+              </label>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                required
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                내용 *
+              </label>
+              <textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                rows={5}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                required
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                이미지 URL (선택)
+              </label>
+              <input
+                type="url"
+                value={imageUrl}
+                onChange={(e) => setImageUrl(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="https://example.com/image.jpg"
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? '제출 중...' : '신고 접수'}
+            </button>
+          </form>
+        </div>
+
+        <div className="bg-white rounded-lg shadow-md p-6">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-xl font-semibold">내 신고 목록</h2>
+            <button
+              onClick={handleLoadMyReports}
+              className="bg-gray-600 text-white py-2 px-4 rounded-md hover:bg-gray-700"
+            >
+              {showMyReports ? '새로고침' : '조회'}
+            </button>
+          </div>
+
+          {showMyReports && (
+            <div className="space-y-4">
+              {myReports.length === 0 ? (
+                <p className="text-gray-500">신고 내역이 없습니다.</p>
+              ) : (
+                myReports.map((report) => (
+                  <div key={report.id} className="border border-gray-200 rounded-md p-4">
+                    <div className="flex justify-between items-start mb-2">
+                      <div>
+                        <h3 className="font-semibold">{report.title}</h3>
+                        <p className="text-sm text-gray-600">
+                          {REPORT_TYPES[report.type as keyof typeof REPORT_TYPES] || report.type}
+                        </p>
+                      </div>
+                      <span className={`px-2 py-1 rounded text-sm ${
+                        report.status === 'APPROVED' ? 'bg-green-100 text-green-800' :
+                        report.status === 'REJECTED' ? 'bg-red-100 text-red-800' :
+                        report.status === 'OPEN' ? 'bg-blue-100 text-blue-800' :
+                        'bg-gray-100 text-gray-800'
+                      }`}>
+                        {report.status}
+                      </span>
+                    </div>
+                    <p className="text-sm text-gray-700 mb-2">{report.content}</p>
+                    <p className="text-xs text-gray-500">
+                      접수일: {new Date(report.createdAt).toLocaleString('ko-KR')}
+                    </p>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/components/ReportModal.tsx
+++ b/components/ReportModal.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useState } from 'react';
+import { createReport, type CreateReportRequest } from '@/lib/api';
+
+interface ReportModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  rentId: number;
+  reportTypes: Array<{ value: string; label: string }>;
+  isOwner?: boolean; // owner인 경우 보증금 자동결제 관련 신고 가능
+}
+
+export default function ReportModal({ isOpen, onClose, rentId, reportTypes, isOwner = false }: ReportModalProps) {
+  const [reportType, setReportType] = useState('');
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [imageUrl, setImageUrl] = useState('');
+  const [delayDays, setDelayDays] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!reportType || !title || !content) {
+      alert('모든 필수 항목을 입력해주세요.');
+      return;
+    }
+
+    if (reportType === 'RETURN_DELAY' && (!delayDays || parseInt(delayDays) <= 0)) {
+      alert('반납 연체 신고 시 연체일수를 입력해주세요.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const request: CreateReportRequest = {
+        rentId,
+        type: reportType,
+        title,
+        content,
+        imageUrl: imageUrl || undefined,
+        delayDays: delayDays ? parseInt(delayDays) : undefined,
+      };
+
+      await createReport(request);
+      alert('신고가 접수되었습니다.');
+      // 폼 초기화
+      setReportType('');
+      setTitle('');
+      setContent('');
+      setImageUrl('');
+      setDelayDays('');
+      onClose();
+    } catch (error: any) {
+      alert(`신고 접수 실패: ${error.message}`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-6 w-full max-w-md mx-4 max-h-[90vh] overflow-y-auto">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-xl font-bold">신고하기</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700 text-2xl"
+          >
+            ×
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              신고 유형 *
+            </label>
+            <select
+              value={reportType}
+              onChange={(e) => setReportType(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              required
+            >
+              <option value="">선택하세요</option>
+              {reportTypes.map((type) => (
+                <option key={type.value} value={type.value}>
+                  {type.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {reportType === 'RETURN_DELAY' && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                연체일수 *
+              </label>
+              <input
+                type="number"
+                value={delayDays}
+                onChange={(e) => setDelayDays(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                min="1"
+                required
+              />
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              제목 *
+            </label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              내용 *
+            </label>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              rows={5}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              이미지 URL (선택)
+            </label>
+            <input
+              type="url"
+              value={imageUrl}
+              onChange={(e) => setImageUrl(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="https://example.com/image.jpg"
+            />
+          </div>
+
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 bg-gray-200 text-gray-800 py-2 px-4 rounded-md hover:bg-gray-300"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? '제출 중...' : '신고 접수'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -729,3 +729,98 @@ export async function deleteUserCard() {
   });
 }
 
+// 신고 관련 타입
+export interface ReportResponse {
+  id: number;
+  rentId: number;
+  userId: number;
+  title: string;
+  content: string;
+  type: string;
+  status: string;
+  imageUrl: string | null;
+  delayDays: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateReportRequest {
+  rentId: number;
+  type: string;
+  title: string;
+  content: string;
+  imageUrl?: string;
+  delayDays?: number;
+}
+
+// 신고 생성
+export async function createReport(request: CreateReportRequest) {
+  const response = await apiFetch<{
+    isSuccess: boolean;
+    code: string;
+    message: string;
+    result: ReportResponse;
+  }>('/reports', {
+    method: 'POST',
+    body: JSON.stringify(request)
+  });
+  return response.result;
+}
+
+// 신고 조회
+export async function getReport(reportId: number) {
+  const response = await apiFetch<{
+    isSuccess: boolean;
+    code: string;
+    message: string;
+    result: ReportResponse;
+  }>(`/reports/${reportId}`);
+  return response.result;
+}
+
+// 내 신고 목록 조회
+export async function getMyReports() {
+  const response = await apiFetch<{
+    isSuccess: boolean;
+    code: string;
+    message: string;
+    result: ReportResponse[];
+  }>('/reports/my');
+  return response.result;
+}
+
+// 관리자: 신고 승인/거부
+export async function approveReport(reportId: number, approved: boolean) {
+  const response = await apiFetch<{
+    isSuccess: boolean;
+    code: string;
+    message: string;
+    result: ReportResponse;
+  }>(`/admin/reports/${reportId}/approve?approved=${approved}`, {
+    method: 'POST'
+  });
+  return response.result;
+}
+
+// 관리자: 모든 신고 목록 조회
+export async function getAllReports() {
+  const response = await apiFetch<{
+    isSuccess: boolean;
+    code: string;
+    message: string;
+    result: ReportResponse[];
+  }>('/admin/reports');
+  return response.result;
+}
+
+// 관리자: 상태별 신고 목록 조회
+export async function getReportsByStatus(status: string) {
+  const response = await apiFetch<{
+    isSuccess: boolean;
+    code: string;
+    message: string;
+    result: ReportResponse[];
+  }>(`/admin/reports/status/${status}`);
+  return response.result;
+}
+


### PR DESCRIPTION
- 관리자 페이지 생성 - role이 admin인 유저만 접속 가능하도록 제한
- 관리자 페이지에서 신고 승인하는 api 연동
- 채팅방에서 신고 생성하도록 api 연동

[신고하기]
<img width="2000" height="873" alt="image" src="https://github.com/user-attachments/assets/1d984366-dc29-4af9-80cd-0685e7809004" />

[관리자 신고 승인]
<img width="2000" height="952" alt="image" src="https://github.com/user-attachments/assets/d6fe51ee-011e-48ce-b41f-d6ff05966dc7" />
